### PR TITLE
fix: correct names

### DIFF
--- a/src/app/persoonsgegevens/templates/persoonsgegevens.mustache
+++ b/src/app/persoonsgegevens/templates/persoonsgegevens.mustache
@@ -124,8 +124,12 @@
                             <td>{{Persoon.Persoonsgegevens.Voorvoegsel}}</td>
                         </tr>
                         <tr>
-                            <th>Achternaam</th>
+                            <th>Geslachtsnaam</th>
                             <td>{{Persoon.Persoonsgegevens.Geslachtsnaam}}</td>
+                        </tr>
+                        <tr>
+                            <th>Achternaam</th>
+                            <td>{{Persoon.Persoonsgegevens.Achternaam}}</td>
                         </tr>
                         <tr>
                             <th>Geboortedatum</th>

--- a/src/app/persoonsgegevens/templates/persoonsgegevens.mustache
+++ b/src/app/persoonsgegevens/templates/persoonsgegevens.mustache
@@ -120,12 +120,12 @@
                             <td>{{Persoon.Persoonsgegevens.Voornamen}}</td>
                         </tr>
                         <tr>
-                            <th>Tussenvoegsel</th>
+                            <th>Voorvoegsel</th>
                             <td>{{Persoon.Persoonsgegevens.Voorvoegsel}}</td>
                         </tr>
                         <tr>
                             <th>Achternaam</th>
-                            <td>{{Persoon.Persoonsgegevens.Achternaam}}</td>
+                            <td>{{Persoon.Persoonsgegevens.Geslachtsnaam}}</td>
                         </tr>
                         <tr>
                             <th>Geboortedatum</th>

--- a/test/__snapshots__/main.test.ts.snap
+++ b/test/__snapshots__/main.test.ts.snap
@@ -52,7 +52,7 @@ Object {
     },
     \\"build\\": {
       \\"commands\\": [
-        \\"cdk-assets --path \\\\\\"assembly-test-mijn-gegevens-api/testmijngegevensapipersoonsgegevensapi9BDC5B79.assets.json\\\\\\" --verbose publish \\\\\\"36658333e8a5c2fb05395d47451de6f749f39364f34a77044cc17ce500c86248:test-eu-west-1\\\\\\"\\"
+        \\"cdk-assets --path \\\\\\"assembly-test-mijn-gegevens-api/testmijngegevensapipersoonsgegevensapi9BDC5B79.assets.json\\\\\\" --verbose publish \\\\\\"0b736357bc89baa42c86af6113a2a848d60e90c22cc0a1166575ba96f99f89d7:test-eu-west-1\\\\\\"\\"
       ]
     }
   }


### PR DESCRIPTION
We gaven voorvoegsel + achternaam weer. Dat is dubbel met het voorvoegsel, nu weergave van geslachtsnaam, en daarna totale achternaam.

Fixes #8