### PR TITLE
feat: Self-host font

### DIFF
--- a/src/shared/header.mustache
+++ b/src/shared/header.mustache
@@ -12,24 +12,25 @@
     <link rel="preconnect" 
           href="https://fonts.gstatic.com/" 
           crossorigin="anonymous">
+    
     <link rel="preload" 
           as="font" 
-          href="https://componenten.nijmegen.nl/v6.1.0/oranda_bold_bt.04c85cb2.woff2" 
+          href="/static/fonts/oranda_bold_bt.04c85cb2.woff2" 
           type="font/woff2"
           crossorigin="anonymous">
     <link rel="preload" 
           as="font" 
-          href="https://componenten.nijmegen.nl/v6.1.0/oranda_bold_bt.8e266873.woff" 
+          href="/static/fonts/oranda_bold_bt.8e266873.woff" 
           type="font/woff"
           crossorigin="anonymous">
     <link rel="preload" 
           as="font" 
-          href="https://componenten.nijmegen.nl/v6.1.0/oranda_bt.bde3d05f.woff2" 
+          href="/static/fonts/oranda_bt.bde3d05f.woff2" 
           type="font/woff2"
           crossorigin="anonymous">
     <link rel="preload" 
           as="font" 
-          href="https://componenten.nijmegen.nl/v6.1.0/oranda_bt.05235f9a.woff" 
+          href="/static/fonts/oranda_bt.05235f9a.woff" 
           type="font/woff"
           crossorigin="anonymous">
 

--- a/test/__snapshots__/main.test.ts.snap
+++ b/test/__snapshots__/main.test.ts.snap
@@ -52,7 +52,7 @@ Object {
     },
     \\"build\\": {
       \\"commands\\": [
-        \\"cdk-assets --path \\\\\\"assembly-test-mijn-gegevens-api/testmijngegevensapipersoonsgegevensapi9BDC5B79.assets.json\\\\\\" --verbose publish \\\\\\"e13870b383ceefcf710806cbc858e8a9f34eb8016face415b821a8e5b9c5b5a8:test-eu-west-1\\\\\\"\\"
+        \\"cdk-assets --path \\\\\\"assembly-test-mijn-gegevens-api/testmijngegevensapipersoonsgegevensapi9BDC5B79.assets.json\\\\\\" --verbose publish \\\\\\"e18da389c58a267d9ba8065e28a86194fa13e65d2d5771132b393ba6c6f4a58b:test-eu-west-1\\\\\\"\\"
       ]
     }
   }


### PR DESCRIPTION
Safari wil geen woff2 (wel de woff)-fonts laden zonder correcte CORS-headers. Zo te zien zet componenten.nijmegen.nl geen Access-Control-Allow-Origin header, dus laden de fonts niet. De .woff laden wel, maar worden niet gebruikt (soms?). Op nijmegen.nl wordt alles op het eigen domein gehost, en lopen ze hier dus niet (meer) tegenaan. Voor nu doen we hetzelfde.

Fixes https://github.com/GemeenteNijmegen/mijn-nijmegen/issues/88