### PR TITLE
feat: error messages

### DIFF
--- a/src/app/persoonsgegevens/ApiClient.js
+++ b/src/app/persoonsgegevens/ApiClient.js
@@ -34,15 +34,18 @@ class ApiClient {
      * @returns string private key
      */
      async getPrivateKey() {
-        if(!this.privatekey && process.env.MTLS_PRIVATE_KEY_ARN) { 
+        if(!this.privatekey) { 
+            if(!process.env.MTLS_PRIVATE_KEY_ARN) {
+                throw new Error ('no secret arn provided');
+            }
             const secretsManagerClient = new SecretsManagerClient();
             const command = new GetSecretValueCommand({ SecretId: process.env.MTLS_PRIVATE_KEY_ARN });
             const data = await secretsManagerClient.send(command);
             // Depending on whether the secret is a string or binary, one of these fields will be populated.
             if ('SecretString' in data) {
                 this.privatekey = data.SecretString
-            } else {      
-                console.log('no secret value found');
+            } else {
+                throw new Error('No secret value found');
             }
         }
         return this.privatekey;
@@ -85,19 +88,17 @@ class ApiClient {
                 // The request was made and the server responded with a status code
                 // that falls out of the range of 2xx
                 console.log('http status for ' + endpoint + ': ' + error.response.status);
-                return error.response.data;
-                console.debug('return response from ' + endpoint);
+                
               } else if (error.request) {
                 // The request was made but no response was received
                 // `error.request` is an instance of XMLHttpRequest in the browser and an instance of
                 // http.ClientRequest in node.js
                 console.error(error?.code);
-                return '';
               } else {
                 // Something happened in setting up the request that triggered an Error
-                console.error('Error', error.message);
-                return '';
+                console.error(error.message);
             }
+            throw new Error('Het ophalen van gegevens is misgegaan.');
         }
     }
 

--- a/src/app/persoonsgegevens/BrpApi.js
+++ b/src/app/persoonsgegevens/BrpApi.js
@@ -7,11 +7,19 @@ class BrpApi {
     }
 
     async getBrpData(bsn) {
-        let data = await this.client.requestData(this.endpoint, {"bsn": bsn}, {'Content-type': 'application/json'});
-        if(data?.Persoon) {
+        try {
+            let data = await this.client.requestData(this.endpoint, {"bsn": bsn}, {'Content-type': 'application/json'});
+            if(data?.Persoon) {
+                return data;
+            } else {
+                throw new Error('Er konden geen persoonsgegevens opgehaald worden.');
+            }
+        } catch (error) {
+            const data = {
+                'error' : error.message
+            }
             return data;
         }
-        return false;
     }
 }
 

--- a/src/app/persoonsgegevens/package-lock.json
+++ b/src/app/persoonsgegevens/package-lock.json
@@ -18,6 +18,7 @@
       },
       "devDependencies": {
         "@aws-sdk/types": "3.47.0",
+        "axios-mock-adapter": "^1.20.0",
         "dotenv": "^16.0.0",
         "jest-aws-client-mock": "0.0.24"
       }
@@ -992,6 +993,20 @@
         "follow-redirects": "^1.14.8"
       }
     },
+    "node_modules/axios-mock-adapter": {
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/axios-mock-adapter/-/axios-mock-adapter-1.20.0.tgz",
+      "integrity": "sha512-shZRhTjLP0WWdcvHKf3rH3iW9deb3UdKbdnKUoHmmsnBhVXN3sjPJM6ZvQ2r/ywgvBVQrMnjrSyQab60G1sr2w==",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "is-blob": "^2.1.0",
+        "is-buffer": "^2.0.5"
+      },
+      "peerDependencies": {
+        "axios": ">= 0.9.0"
+      }
+    },
     "node_modules/bowser": {
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
@@ -1022,6 +1037,12 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
+    },
     "node_modules/fast-xml-parser": {
       "version": "3.19.0",
       "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.19.0.tgz",
@@ -1051,6 +1072,41 @@
         "debug": {
           "optional": true
         }
+      }
+    },
+    "node_modules/is-blob": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-blob/-/is-blob-2.1.0.tgz",
+      "integrity": "sha512-SZ/fTft5eUhQM6oF/ZaASFDEdbFVe89Imltn9uZr03wdKMcWNVYSMjQPFtg05QuNkt5l5c135ElvXEQG0rk4tw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-buffer": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/jest-aws-client-mock": {
@@ -1922,6 +1978,17 @@
         "follow-redirects": "^1.14.8"
       }
     },
+    "axios-mock-adapter": {
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/axios-mock-adapter/-/axios-mock-adapter-1.20.0.tgz",
+      "integrity": "sha512-shZRhTjLP0WWdcvHKf3rH3iW9deb3UdKbdnKUoHmmsnBhVXN3sjPJM6ZvQ2r/ywgvBVQrMnjrSyQab60G1sr2w==",
+      "dev": true,
+      "requires": {
+        "fast-deep-equal": "^3.1.3",
+        "is-blob": "^2.1.0",
+        "is-buffer": "^2.0.5"
+      }
+    },
     "bowser": {
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
@@ -1943,6 +2010,12 @@
       "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
       "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="
     },
+    "fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
+    },
     "fast-xml-parser": {
       "version": "3.19.0",
       "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.19.0.tgz",
@@ -1952,6 +2025,18 @@
       "version": "1.14.9",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
       "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w=="
+    },
+    "is-blob": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-blob/-/is-blob-2.1.0.tgz",
+      "integrity": "sha512-SZ/fTft5eUhQM6oF/ZaASFDEdbFVe89Imltn9uZr03wdKMcWNVYSMjQPFtg05QuNkt5l5c135ElvXEQG0rk4tw==",
+      "dev": true
+    },
+    "is-buffer": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+      "dev": true
     },
     "jest-aws-client-mock": {
       "version": "0.0.24",

--- a/src/app/persoonsgegevens/package.json
+++ b/src/app/persoonsgegevens/package.json
@@ -16,8 +16,9 @@
   },
   "devDependencies": {
     "@aws-sdk/types": "3.47.0",
-    "jest-aws-client-mock": "0.0.24",
-    "dotenv": "^16.0.0"
+    "axios-mock-adapter": "^1.20.0",
+    "dotenv": "^16.0.0",
+    "jest-aws-client-mock": "0.0.24"
   },
   "author": "",
   "license": "ISC"

--- a/src/app/persoonsgegevens/requestHandler.js
+++ b/src/app/persoonsgegevens/requestHandler.js
@@ -29,6 +29,7 @@ exports.requestHandler = async (cookies, apiClient, dynamoDBClient) => {
     const bsn = session.getValue('bsn');
     const brpApi = new BrpApi(apiClient);
     console.timeLog('request', 'Brp Api');
+
     const brpData = await brpApi.getBrpData(bsn);
     const data = brpData;
     data.volledigenaam = brpData?.Persoon?.Persoonsgegevens?.Naam ? brpData.Persoon.Persoonsgegevens.Naam : 'Onbekende gebruiker';

--- a/src/app/persoonsgegevens/templates/persoonsgegevens.mustache
+++ b/src/app/persoonsgegevens/templates/persoonsgegevens.mustache
@@ -7,6 +7,7 @@
             <div class="col-12">
                 <h1>Mijn gegevens</h1>
                 <p class="lead">Hier vindt u een overzicht van uw persoons- en adresgegevens.</p>
+                {{^error}}
                 <section>
                 <h2>Persoonsgegevens</h2>
                 <table class="responsive-table">
@@ -69,6 +70,11 @@
                     </tbody>
                 </table>
                 </section>
+                {{/error}}
+                {{#error}}
+                <h2>Er is iets misgegaan</h2>
+                <p>{{error}}</p>
+                {{/error}}
             </div>
         </div>
     </div>

--- a/src/app/persoonsgegevens/tests/apiclient.test.ts
+++ b/src/app/persoonsgegevens/tests/apiclient.test.ts
@@ -1,0 +1,164 @@
+import { ApiClient } from '../ApiClient';
+import { SecretsManagerClient, GetSecretValueCommandOutput } from '@aws-sdk/client-secrets-manager';
+import { SSMClient, GetParameterCommandOutput } from "@aws-sdk/client-ssm"; // ES Modules import
+import { mockClient } from 'jest-aws-client-mock';
+import MockAdapter from 'axios-mock-adapter';
+import axios from 'axios';
+
+
+const secretsMock = mockClient(SecretsManagerClient);
+const parameterStoreMock = mockClient(SSMClient);
+const axiosMock = new MockAdapter(axios);
+
+if(process.env.VERBOSETESTS!='True') {
+    global.console.error = jest.fn();
+    global.console.time = jest.fn();
+    global.console.log = jest.fn();
+  }
+  
+beforeEach(() => {
+    secretsMock.mockReset();
+    parameterStoreMock.mockReset();
+    axiosMock.reset();
+});
+
+describe('Init', () => {
+    test('Init succeeds', async () => {
+        //required env params:
+        process.env.MTLS_PRIVATE_KEY_ARN = 'testarn';
+
+        const secretsOutput: GetSecretValueCommandOutput = {
+            $metadata: {},
+            SecretString: 'test'
+        };
+        secretsMock.mockImplementation(() => secretsOutput);
+        const ssmOutput: GetParameterCommandOutput = {
+            $metadata: {},
+            Parameter: {
+                Value: 'test'
+            },
+        };
+        secretsMock.mockImplementation(() => secretsOutput);
+        parameterStoreMock.mockImplementation(() => ssmOutput);
+
+        const apiClient = new ApiClient();
+        await apiClient.init();
+    });
+
+    test('Error getting secret', async () => {
+        //required env params:
+        process.env.MTLS_PRIVATE_KEY_ARN = 'testarn';
+
+        const secretsOutput: GetSecretValueCommandOutput = {
+            $metadata: {},
+        };
+        secretsMock.mockImplementation(() => secretsOutput);
+        const ssmOutput: GetParameterCommandOutput = {
+            $metadata: {},
+            Parameter: {
+                Value: 'test'
+            },
+        };
+        secretsMock.mockImplementation(() => secretsOutput);
+        parameterStoreMock.mockImplementation(() => ssmOutput);
+
+        const apiClient = new ApiClient();
+        expect(async () => {
+            return await apiClient.init();
+        }).rejects.toThrow();
+    });
+
+    test('Without secret arn fails', async () => {
+        //required env params:
+        process.env.MTLS_PRIVATE_KEY_ARN = 'testarn';
+
+        const secretsOutput: GetSecretValueCommandOutput = {
+            $metadata: {},
+        };
+        secretsMock.mockImplementation(() => secretsOutput);
+        const ssmOutput: GetParameterCommandOutput = {
+            $metadata: {},
+            Parameter: {
+                Value: 'test'
+            },
+        };
+        secretsMock.mockImplementation(() => secretsOutput);
+        parameterStoreMock.mockImplementation(() => ssmOutput);
+
+        const apiClient = new ApiClient();
+        expect(async () => {
+            return await apiClient.init();
+        }).rejects.toThrow();
+    });
+});
+
+describe('Requests', () => {
+    test('Return data', async () => {
+        //required env params:
+        testSetup();
+        const returnData = { users: [{ id: 1, name: "John Smith" }] };
+        axiosMock.onPost("/test").reply(200, returnData);
+    
+        const apiClient = new ApiClient();
+        await apiClient.init();
+        const data = await apiClient.requestData('/test', { data: 'test '});
+        expect(data).toEqual(returnData);
+    });
+
+    test('Timeout', async () => {
+        //required env params:
+        testSetup();
+        axiosMock.onPost("/test").timeout();
+    
+        const apiClient = new ApiClient();
+        await apiClient.init();
+        expect(async() => {
+            await apiClient.requestData('/test', { data: 'test '});
+        }).rejects.toThrow();
+        let result: any;
+        try {
+            await apiClient.requestData('/test', { data: 'test '});
+        } catch(error) {
+            result = error;
+        }
+        expect(result.message).toBe('Het ophalen van gegevens is misgegaan.');
+    });
+
+    test('Network error', async () => {
+        //required env params:
+        testSetup();
+        axiosMock.onPost("/test").networkError();
+    
+        const apiClient = new ApiClient();
+        await apiClient.init();
+        expect(async() => {
+            await apiClient.requestData('/test', { data: 'test '});
+        }).rejects.toThrow();
+        let result: any;
+        try {
+            await apiClient.requestData('/test', { data: 'test '});
+        } catch(error) {
+            result = error;
+        }
+        expect(result.message).toBe('Het ophalen van gegevens is misgegaan.');
+    });
+});
+
+function testSetup() {
+    process.env.MTLS_PRIVATE_KEY_ARN = 'testarn';
+
+    const secretsOutput: GetSecretValueCommandOutput = {
+        $metadata: {},
+        SecretString: 'test'
+    };
+    secretsMock.mockImplementation(() => secretsOutput);
+    const ssmOutput: GetParameterCommandOutput = {
+        $metadata: {},
+        Parameter: {
+            Value: 'test'
+        },
+    };
+
+    secretsMock.mockImplementation(() => secretsOutput);
+    parameterStoreMock.mockImplementation(() => ssmOutput);
+}

--- a/src/app/persoonsgegevens/tests/apiclient.test.ts
+++ b/src/app/persoonsgegevens/tests/apiclient.test.ts
@@ -1,164 +1,164 @@
-import { ApiClient } from '../ApiClient';
 import { SecretsManagerClient, GetSecretValueCommandOutput } from '@aws-sdk/client-secrets-manager';
-import { SSMClient, GetParameterCommandOutput } from "@aws-sdk/client-ssm"; // ES Modules import
-import { mockClient } from 'jest-aws-client-mock';
-import MockAdapter from 'axios-mock-adapter';
+import { SSMClient, GetParameterCommandOutput } from '@aws-sdk/client-ssm'; // ES Modules import
 import axios from 'axios';
+import MockAdapter from 'axios-mock-adapter';
+import { mockClient } from 'jest-aws-client-mock';
+import { ApiClient } from '../ApiClient';
 
 
 const secretsMock = mockClient(SecretsManagerClient);
 const parameterStoreMock = mockClient(SSMClient);
 const axiosMock = new MockAdapter(axios);
 
-if(process.env.VERBOSETESTS!='True') {
-    global.console.error = jest.fn();
-    global.console.time = jest.fn();
-    global.console.log = jest.fn();
-  }
-  
+if (process.env.VERBOSETESTS!='True') {
+  global.console.error = jest.fn();
+  global.console.time = jest.fn();
+  global.console.log = jest.fn();
+}
+
 beforeEach(() => {
-    secretsMock.mockReset();
-    parameterStoreMock.mockReset();
-    axiosMock.reset();
+  secretsMock.mockReset();
+  parameterStoreMock.mockReset();
+  axiosMock.reset();
 });
 
 describe('Init', () => {
-    test('Init succeeds', async () => {
-        //required env params:
-        process.env.MTLS_PRIVATE_KEY_ARN = 'testarn';
-
-        const secretsOutput: GetSecretValueCommandOutput = {
-            $metadata: {},
-            SecretString: 'test'
-        };
-        secretsMock.mockImplementation(() => secretsOutput);
-        const ssmOutput: GetParameterCommandOutput = {
-            $metadata: {},
-            Parameter: {
-                Value: 'test'
-            },
-        };
-        secretsMock.mockImplementation(() => secretsOutput);
-        parameterStoreMock.mockImplementation(() => ssmOutput);
-
-        const apiClient = new ApiClient();
-        await apiClient.init();
-    });
-
-    test('Error getting secret', async () => {
-        //required env params:
-        process.env.MTLS_PRIVATE_KEY_ARN = 'testarn';
-
-        const secretsOutput: GetSecretValueCommandOutput = {
-            $metadata: {},
-        };
-        secretsMock.mockImplementation(() => secretsOutput);
-        const ssmOutput: GetParameterCommandOutput = {
-            $metadata: {},
-            Parameter: {
-                Value: 'test'
-            },
-        };
-        secretsMock.mockImplementation(() => secretsOutput);
-        parameterStoreMock.mockImplementation(() => ssmOutput);
-
-        const apiClient = new ApiClient();
-        expect(async () => {
-            return await apiClient.init();
-        }).rejects.toThrow();
-    });
-
-    test('Without secret arn fails', async () => {
-        //required env params:
-        process.env.MTLS_PRIVATE_KEY_ARN = 'testarn';
-
-        const secretsOutput: GetSecretValueCommandOutput = {
-            $metadata: {},
-        };
-        secretsMock.mockImplementation(() => secretsOutput);
-        const ssmOutput: GetParameterCommandOutput = {
-            $metadata: {},
-            Parameter: {
-                Value: 'test'
-            },
-        };
-        secretsMock.mockImplementation(() => secretsOutput);
-        parameterStoreMock.mockImplementation(() => ssmOutput);
-
-        const apiClient = new ApiClient();
-        expect(async () => {
-            return await apiClient.init();
-        }).rejects.toThrow();
-    });
-});
-
-describe('Requests', () => {
-    test('Return data', async () => {
-        //required env params:
-        testSetup();
-        const returnData = { users: [{ id: 1, name: "John Smith" }] };
-        axiosMock.onPost("/test").reply(200, returnData);
-    
-        const apiClient = new ApiClient();
-        await apiClient.init();
-        const data = await apiClient.requestData('/test', { data: 'test '});
-        expect(data).toEqual(returnData);
-    });
-
-    test('Timeout', async () => {
-        //required env params:
-        testSetup();
-        axiosMock.onPost("/test").timeout();
-    
-        const apiClient = new ApiClient();
-        await apiClient.init();
-        expect(async() => {
-            await apiClient.requestData('/test', { data: 'test '});
-        }).rejects.toThrow();
-        let result: any;
-        try {
-            await apiClient.requestData('/test', { data: 'test '});
-        } catch(error) {
-            result = error;
-        }
-        expect(result.message).toBe('Het ophalen van gegevens is misgegaan.');
-    });
-
-    test('Network error', async () => {
-        //required env params:
-        testSetup();
-        axiosMock.onPost("/test").networkError();
-    
-        const apiClient = new ApiClient();
-        await apiClient.init();
-        expect(async() => {
-            await apiClient.requestData('/test', { data: 'test '});
-        }).rejects.toThrow();
-        let result: any;
-        try {
-            await apiClient.requestData('/test', { data: 'test '});
-        } catch(error) {
-            result = error;
-        }
-        expect(result.message).toBe('Het ophalen van gegevens is misgegaan.');
-    });
-});
-
-function testSetup() {
+  test('Init succeeds', async () => {
+    //required env params:
     process.env.MTLS_PRIVATE_KEY_ARN = 'testarn';
 
     const secretsOutput: GetSecretValueCommandOutput = {
-        $metadata: {},
-        SecretString: 'test'
+      $metadata: {},
+      SecretString: 'test',
     };
     secretsMock.mockImplementation(() => secretsOutput);
     const ssmOutput: GetParameterCommandOutput = {
-        $metadata: {},
-        Parameter: {
-            Value: 'test'
-        },
+      $metadata: {},
+      Parameter: {
+        Value: 'test',
+      },
     };
-
     secretsMock.mockImplementation(() => secretsOutput);
     parameterStoreMock.mockImplementation(() => ssmOutput);
+
+    const apiClient = new ApiClient();
+    await apiClient.init();
+  });
+
+  test('Error getting secret', async () => {
+    //required env params:
+    process.env.MTLS_PRIVATE_KEY_ARN = 'testarn';
+
+    const secretsOutput: GetSecretValueCommandOutput = {
+      $metadata: {},
+    };
+    secretsMock.mockImplementation(() => secretsOutput);
+    const ssmOutput: GetParameterCommandOutput = {
+      $metadata: {},
+      Parameter: {
+        Value: 'test',
+      },
+    };
+    secretsMock.mockImplementation(() => secretsOutput);
+    parameterStoreMock.mockImplementation(() => ssmOutput);
+
+    const apiClient = new ApiClient();
+    return expect(async () => {
+      return apiClient.init();
+    }).rejects.toThrow();
+  });
+
+  test('Without secret arn fails', async () => {
+    //required env params:
+    process.env.MTLS_PRIVATE_KEY_ARN = 'testarn';
+
+    const secretsOutput: GetSecretValueCommandOutput = {
+      $metadata: {},
+    };
+    secretsMock.mockImplementation(() => secretsOutput);
+    const ssmOutput: GetParameterCommandOutput = {
+      $metadata: {},
+      Parameter: {
+        Value: 'test',
+      },
+    };
+    secretsMock.mockImplementation(() => secretsOutput);
+    parameterStoreMock.mockImplementation(() => ssmOutput);
+
+    const apiClient = new ApiClient();
+    return expect(async () => {
+      return apiClient.init();
+    }).rejects.toThrow();
+  });
+});
+
+describe('Requests', () => {
+  test('Return data', async () => {
+    //required env params:
+    testSetup();
+    const returnData = { users: [{ id: 1, name: 'John Smith' }] };
+    axiosMock.onPost('/test').reply(200, returnData);
+
+    const apiClient = new ApiClient();
+    await apiClient.init();
+    const data = await apiClient.requestData('/test', { data: 'test ' });
+    expect(data).toEqual(returnData);
+  });
+
+  test('Timeout', async () => {
+    //required env params:
+    testSetup();
+    axiosMock.onPost('/test').timeout();
+
+    const apiClient = new ApiClient();
+    await apiClient.init();
+    return expect(async() => {
+      await apiClient.requestData('/test', { data: 'test ' });
+    }).rejects.toThrow();
+    let result: any;
+    try {
+      await apiClient.requestData('/test', { data: 'test ' });
+    } catch (error) {
+      result = error;
+    }
+    expect(result.message).toBe('Het ophalen van gegevens is misgegaan.');
+  });
+
+  test('Network error', async () => {
+    //required env params:
+    testSetup();
+    axiosMock.onPost('/test').networkError();
+
+    const apiClient = new ApiClient();
+    await apiClient.init();
+    return expect(async() => {
+      await apiClient.requestData('/test', { data: 'test ' });
+    }).rejects.toThrow();
+    let result: any;
+    try {
+      await apiClient.requestData('/test', { data: 'test ' });
+    } catch (error) {
+      result = error;
+    }
+    expect(result.message).toBe('Het ophalen van gegevens is misgegaan.');
+  });
+});
+
+function testSetup() {
+  process.env.MTLS_PRIVATE_KEY_ARN = 'testarn';
+
+  const secretsOutput: GetSecretValueCommandOutput = {
+    $metadata: {},
+    SecretString: 'test',
+  };
+  secretsMock.mockImplementation(() => secretsOutput);
+  const ssmOutput: GetParameterCommandOutput = {
+    $metadata: {},
+    Parameter: {
+      Value: 'test',
+    },
+  };
+
+  secretsMock.mockImplementation(() => secretsOutput);
+  parameterStoreMock.mockImplementation(() => ssmOutput);
 }

--- a/src/app/persoonsgegevens/tests/brp.test.ts
+++ b/src/app/persoonsgegevens/tests/brp.test.ts
@@ -3,6 +3,12 @@ import { ApiClient } from '../ApiClient';
 import { BrpApi } from '../BrpApi';
 import { FileApiClient } from '../FileApiClient';
 
+if(process.env.VERBOSETESTS!='True') {
+  global.console.error = jest.fn();
+  global.console.time = jest.fn();
+  global.console.log = jest.fn();
+}
+
 
 async function getStringFromFilePath(filePath: string) {
   return new Promise((res, rej) => {
@@ -55,5 +61,5 @@ test('Api', async () => {
   const client = new ApiClient(cert, key, ca);
   const api = new BrpApi(client);
   const result = await api.getBrpData(12345678);
-  expect(result).toBe(false);
+  expect(result).toHaveProperty('error');
 });

--- a/src/app/persoonsgegevens/tests/brp.test.ts
+++ b/src/app/persoonsgegevens/tests/brp.test.ts
@@ -3,7 +3,7 @@ import { ApiClient } from '../ApiClient';
 import { BrpApi } from '../BrpApi';
 import { FileApiClient } from '../FileApiClient';
 
-if(process.env.VERBOSETESTS!='True') {
+if (process.env.VERBOSETESTS!='True') {
   global.console.error = jest.fn();
   global.console.time = jest.fn();
   global.console.log = jest.fn();

--- a/src/app/persoonsgegevens/tests/persoonsgegevens.test.ts
+++ b/src/app/persoonsgegevens/tests/persoonsgegevens.test.ts
@@ -1,10 +1,20 @@
-import { writeFile } from 'fs';
+import * as fs from 'fs';
 import * as path from 'path';
 import { DynamoDBClient, GetItemCommandOutput } from '@aws-sdk/client-dynamodb';
 import { SecretsManagerClient, GetSecretValueCommandOutput } from '@aws-sdk/client-secrets-manager';
+import { SSMClient, GetParameterCommandOutput } from "@aws-sdk/client-ssm";
 import { mockClient } from 'jest-aws-client-mock';
-import { FileApiClient } from '../FileApiClient';
+import { ApiClient } from '../ApiClient';
 import { requestHandler } from '../requestHandler';
+import MockAdapter from 'axios-mock-adapter';
+import axios from 'axios';
+
+
+if(process.env.VERBOSETESTS!='True') {
+  global.console.error = jest.fn();
+  global.console.time = jest.fn();
+  global.console.log = jest.fn();
+}
 
 beforeAll(() => {
   global.console.log = jest.fn();
@@ -15,15 +25,35 @@ beforeAll(() => {
   process.env.CLIENT_SECRET_ARN = '123';
   process.env.OIDC_CLIENT_ID = '1234';
   process.env.OIDC_SCOPE = 'openid';
+
+  process.env.MTLS_PRIVATE_KEY_ARN = 'testarn';
+
+    const secretsOutput: GetSecretValueCommandOutput = {
+        $metadata: {},
+        SecretString: 'test'
+    };
+    secretsMock.mockImplementation(() => secretsOutput);
+    const ssmOutput: GetParameterCommandOutput = {
+        $metadata: {},
+        Parameter: {
+            Value: 'test'
+        },
+    };
+
+    secretsMock.mockImplementation(() => secretsOutput);
+    parameterStoreMock.mockImplementation(() => ssmOutput);
 });
 
 
 const ddbMock = mockClient(DynamoDBClient);
 const secretsMock = mockClient(SecretsManagerClient);
+const axiosMock = new MockAdapter(axios);
+const parameterStoreMock = mockClient(SSMClient);
 
 beforeEach(() => {
   ddbMock.mockReset();
   secretsMock.mockReset();
+  axiosMock.reset();
   const getItemOutput: Partial<GetItemCommandOutput> = {
     Item: {
       loggedin: {
@@ -40,27 +70,87 @@ beforeEach(() => {
   ddbMock.mockImplementation(() => getItemOutput);
 });
 
-test('Returns 200', async () => {
-  const output: GetSecretValueCommandOutput = {
-    $metadata: {},
-    SecretString: 'ditiseennepgeheim',
-  };
-  secretsMock.mockImplementation(() => output);
-  const client = new FileApiClient();
-  const dynamoDBClient = new DynamoDBClient({});
-  const result = await requestHandler('session=12345', client, dynamoDBClient);
-  expect(result.statusCode).toBe(200);
+describe('Requests', () => {
+  test('Return status 200', async () => {
+    const output: GetSecretValueCommandOutput = {
+      $metadata: {},
+      SecretString: 'ditiseennepgeheim',
+    };
+    secretsMock.mockImplementation(() => output);
+    const file = 'brp-12345678.json';
+    const filePath = path.join('responses', file);
+    const returnData = await getStringFromFilePath(filePath)
+    .then((data: any) => { 
+        return JSON.parse(data);
+    });
+    axiosMock.onPost().reply(200, returnData);
+
+    const client = new ApiClient();
+    const dynamoDBClient = new DynamoDBClient({});
+    const result = await requestHandler('session=12345', client, dynamoDBClient);
+    expect(result.statusCode).toBe(200);
+    fs.writeFile(path.join(__dirname, 'output', 'test-error.html'), result.body, () => {});
+  });
+
+  test('Return error page', async () => {
+    const output: GetSecretValueCommandOutput = {
+      $metadata: {},
+      SecretString: 'ditiseennepgeheim',
+    };
+    secretsMock.mockImplementation(() => output);
+    axiosMock.onPost().reply(200, {
+    });
+
+    const client = new ApiClient();
+    const dynamoDBClient = new DynamoDBClient({});
+    const result = await requestHandler('session=12345', client, dynamoDBClient);
+    expect(result.statusCode).toBe(200);
+    fs.writeFile(path.join(__dirname, 'output', 'test-error.html'), result.body, () => {});
+  });
+
+  test('Return error page on timeout', async () => {
+    const output: GetSecretValueCommandOutput = {
+      $metadata: {},
+      SecretString: 'ditiseennepgeheim',
+    };
+    secretsMock.mockImplementation(() => output);
+    axiosMock.onPost().timeout();
+
+    const client = new ApiClient();
+    const dynamoDBClient = new DynamoDBClient({});
+    const result = await requestHandler('session=12345', client, dynamoDBClient);
+    expect(result.statusCode).toBe(200);
+    fs.writeFile(path.join(__dirname, 'output', 'test-timeout.html'), result.body, () => {});
+  });
+
+
+test('Show overview page', async () => {
+    const output: GetSecretValueCommandOutput = {
+      $metadata: {},
+      SecretString: 'ditiseennepgeheim',
+    };
+    secretsMock.mockImplementation(() => output);
+    const file = 'brp-12345678.json';
+    const filePath = path.join('responses', file);
+    const returnData = await getStringFromFilePath(filePath)
+    .then((data: any) => { 
+        return JSON.parse(data);
+    });
+    axiosMock.onPost().reply(200, returnData);
+    const client = new ApiClient();
+    const dynamoDBClient = new DynamoDBClient({ region: 'eu-west-1' });
+    const result = await requestHandler('session=12345', client, dynamoDBClient);
+    expect(result.body).toMatch('Mijn gegevens');
+    fs.writeFile(path.join(__dirname, 'output', 'test.html'), result.body, () => {});
+  })
 });
 
-test('Shows overview page', async () => {
-  const output: GetSecretValueCommandOutput = {
-    $metadata: {},
-    SecretString: 'ditiseennepgeheim',
-  };
-  secretsMock.mockImplementation(() => output);
-  const client = new FileApiClient();
-  const dynamoDBClient = new DynamoDBClient({ region: 'eu-west-1' });
-  const result = await requestHandler('session=12345', client, dynamoDBClient);
-  expect(result.body).toMatch('Mijn gegevens');
-  writeFile(path.join(__dirname, 'output', 'test.html'), result.body, () => {});
-});
+async function getStringFromFilePath(filePath: string) {
+  return new Promise((res, rej) => {
+      fs.readFile(path.join(__dirname, filePath), (err, data) => {
+          if (err)
+              return rej(err);
+          return res(data.toString());
+      });
+  });
+}

--- a/src/app/persoonsgegevens/tests/persoonsgegevens.test.ts
+++ b/src/app/persoonsgegevens/tests/persoonsgegevens.test.ts
@@ -2,15 +2,15 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { DynamoDBClient, GetItemCommandOutput } from '@aws-sdk/client-dynamodb';
 import { SecretsManagerClient, GetSecretValueCommandOutput } from '@aws-sdk/client-secrets-manager';
-import { SSMClient, GetParameterCommandOutput } from "@aws-sdk/client-ssm";
+import { SSMClient, GetParameterCommandOutput } from '@aws-sdk/client-ssm';
+import axios from 'axios';
+import MockAdapter from 'axios-mock-adapter';
 import { mockClient } from 'jest-aws-client-mock';
 import { ApiClient } from '../ApiClient';
 import { requestHandler } from '../requestHandler';
-import MockAdapter from 'axios-mock-adapter';
-import axios from 'axios';
 
 
-if(process.env.VERBOSETESTS!='True') {
+if (process.env.VERBOSETESTS!='True') {
   global.console.error = jest.fn();
   global.console.time = jest.fn();
   global.console.log = jest.fn();
@@ -28,20 +28,20 @@ beforeAll(() => {
 
   process.env.MTLS_PRIVATE_KEY_ARN = 'testarn';
 
-    const secretsOutput: GetSecretValueCommandOutput = {
-        $metadata: {},
-        SecretString: 'test'
-    };
-    secretsMock.mockImplementation(() => secretsOutput);
-    const ssmOutput: GetParameterCommandOutput = {
-        $metadata: {},
-        Parameter: {
-            Value: 'test'
-        },
-    };
+  const secretsOutput: GetSecretValueCommandOutput = {
+    $metadata: {},
+    SecretString: 'test',
+  };
+  secretsMock.mockImplementation(() => secretsOutput);
+  const ssmOutput: GetParameterCommandOutput = {
+    $metadata: {},
+    Parameter: {
+      Value: 'test',
+    },
+  };
 
-    secretsMock.mockImplementation(() => secretsOutput);
-    parameterStoreMock.mockImplementation(() => ssmOutput);
+  secretsMock.mockImplementation(() => secretsOutput);
+  parameterStoreMock.mockImplementation(() => ssmOutput);
 });
 
 
@@ -80,9 +80,9 @@ describe('Requests', () => {
     const file = 'brp-12345678.json';
     const filePath = path.join('responses', file);
     const returnData = await getStringFromFilePath(filePath)
-    .then((data: any) => { 
+      .then((data: any) => {
         return JSON.parse(data);
-    });
+      });
     axiosMock.onPost().reply(200, returnData);
 
     const client = new ApiClient();
@@ -124,7 +124,7 @@ describe('Requests', () => {
   });
 
 
-test('Show overview page', async () => {
+  test('Show overview page', async () => {
     const output: GetSecretValueCommandOutput = {
       $metadata: {},
       SecretString: 'ditiseennepgeheim',
@@ -133,24 +133,23 @@ test('Show overview page', async () => {
     const file = 'brp-12345678.json';
     const filePath = path.join('responses', file);
     const returnData = await getStringFromFilePath(filePath)
-    .then((data: any) => { 
+      .then((data: any) => {
         return JSON.parse(data);
-    });
+      });
     axiosMock.onPost().reply(200, returnData);
     const client = new ApiClient();
     const dynamoDBClient = new DynamoDBClient({ region: 'eu-west-1' });
     const result = await requestHandler('session=12345', client, dynamoDBClient);
     expect(result.body).toMatch('Mijn gegevens');
     fs.writeFile(path.join(__dirname, 'output', 'test.html'), result.body, () => {});
-  })
+  });
 });
 
 async function getStringFromFilePath(filePath: string) {
   return new Promise((res, rej) => {
-      fs.readFile(path.join(__dirname, filePath), (err, data) => {
-          if (err)
-              return rej(err);
-          return res(data.toString());
-      });
+    fs.readFile(path.join(__dirname, filePath), (err, data) => {
+      if (err) {return rej(err);}
+      return res(data.toString());
+    });
   });
 }

--- a/test/__snapshots__/main.test.ts.snap
+++ b/test/__snapshots__/main.test.ts.snap
@@ -52,7 +52,7 @@ Object {
     },
     \\"build\\": {
       \\"commands\\": [
-        \\"cdk-assets --path \\\\\\"assembly-test-mijn-gegevens-api/testmijngegevensapipersoonsgegevensapi9BDC5B79.assets.json\\\\\\" --verbose publish \\\\\\"e83e80db007c9f199d00b365d5d5827f4df0db38701755f10c38963ce04b09f8:test-eu-west-1\\\\\\"\\"
+        \\"cdk-assets --path \\\\\\"assembly-test-mijn-gegevens-api/testmijngegevensapipersoonsgegevensapi9BDC5B79.assets.json\\\\\\" --verbose publish \\\\\\"d8a26b2e508cd13b05fd4f26875ba68fa4aefeef37c0f6583f5b2bd0ef3fc28e:test-eu-west-1\\\\\\"\\"
       ]
     }
   }

--- a/test/__snapshots__/main.test.ts.snap
+++ b/test/__snapshots__/main.test.ts.snap
@@ -52,7 +52,7 @@ Object {
     },
     \\"build\\": {
       \\"commands\\": [
-        \\"cdk-assets --path \\\\\\"assembly-test-mijn-gegevens-api/testmijngegevensapipersoonsgegevensapi9BDC5B79.assets.json\\\\\\" --verbose publish \\\\\\"f505dfe1757229a51486057ae2e4555345babd908a7af59885ee8a7813c4cfca:test-eu-west-1\\\\\\"\\"
+        \\"cdk-assets --path \\\\\\"assembly-test-mijn-gegevens-api/testmijngegevensapipersoonsgegevensapi9BDC5B79.assets.json\\\\\\" --verbose publish \\\\\\"521e0814e54a71831a7752dce88d5f2fd728cbcb1ade293d0effda8826943b7f:test-eu-west-1\\\\\\"\\"
       ]
     }
   }

--- a/test/__snapshots__/main.test.ts.snap
+++ b/test/__snapshots__/main.test.ts.snap
@@ -52,7 +52,7 @@ Object {
     },
     \\"build\\": {
       \\"commands\\": [
-        \\"cdk-assets --path \\\\\\"assembly-test-mijn-gegevens-api/testmijngegevensapipersoonsgegevensapi9BDC5B79.assets.json\\\\\\" --verbose publish \\\\\\"521e0814e54a71831a7752dce88d5f2fd728cbcb1ade293d0effda8826943b7f:test-eu-west-1\\\\\\"\\"
+        \\"cdk-assets --path \\\\\\"assembly-test-mijn-gegevens-api/testmijngegevensapipersoonsgegevensapi9BDC5B79.assets.json\\\\\\" --verbose publish \\\\\\"e83e80db007c9f199d00b365d5d5827f4df0db38701755f10c38963ce04b09f8:test-eu-west-1\\\\\\"\\"
       ]
     }
   }


### PR DESCRIPTION
- Always throw errors  from the http api client
- Return error messages from the brp api client
- Show error message on page if required

Onderdeel van https://github.com/GemeenteNijmegen/mijn-nijmegen/issues/96