### PR TITLE
fix: http 500 when directly opened without cookies

### DIFF
--- a/src/app/persoonsgegevens/persoonsgegevensRequestHandler.js
+++ b/src/app/persoonsgegevens/persoonsgegevensRequestHandler.js
@@ -4,7 +4,7 @@ const { Session } = require('@gemeentenijmegen/session');
 const { Response } = require('@gemeentenijmegen/apigateway-http/lib/V2/Response');
 
 exports.persoonsgegevensRequestHandler = async (cookies, apiClient, dynamoDBClient) => {
-    if(!cookies || !apiClient || !dynamoDBClient) { throw new Error('all handler params are required'); }
+    if(!apiClient || !dynamoDBClient) { throw new Error('all handler params are required'); }
     console.time('request');
     console.timeLog('request', 'start request');
     console.timeLog('request', 'finished init');

--- a/src/app/persoonsgegevens/tests/persoonsgegevens.test.ts
+++ b/src/app/persoonsgegevens/tests/persoonsgegevens.test.ts
@@ -150,7 +150,7 @@ describe('Unexpected requests', () => {
 
     const result = await persoonsgegevensRequestHandler('', client, dynamoDBClient);
     expect(result.statusCode).toBe(302);
-    expect(result.headers['Location']).toMatch('/login');
+    expect(result.headers.Location).toMatch('/login');
   });
 });
 

--- a/src/app/persoonsgegevens/tests/persoonsgegevens.test.ts
+++ b/src/app/persoonsgegevens/tests/persoonsgegevens.test.ts
@@ -142,6 +142,18 @@ describe('Requests', () => {
   });
 });
 
+
+describe('Unexpected requests', () => {
+  test('No cookies set should redirect to login page', async() => {
+    const client = new ApiClient('test', 'test', 'test');
+    const dynamoDBClient = new DynamoDBClient({ region: 'eu-west-1' });
+
+    const result = await persoonsgegevensRequestHandler('', client, dynamoDBClient);
+    expect(result.statusCode).toBe(302);
+    expect(result.headers['Location']).toMatch('/login');
+  });
+});
+
 async function getStringFromFilePath(filePath: string) {
   return new Promise((res, rej) => {
     fs.readFile(path.join(__dirname, filePath), (err, data) => {

--- a/test/__snapshots__/main.test.ts.snap
+++ b/test/__snapshots__/main.test.ts.snap
@@ -52,7 +52,7 @@ Object {
     },
     \\"build\\": {
       \\"commands\\": [
-        \\"cdk-assets --path \\\\\\"assembly-test-mijn-gegevens-api/testmijngegevensapipersoonsgegevensapi9BDC5B79.assets.json\\\\\\" --verbose publish \\\\\\"b811446fe28000c22f920ceba9a6f8f5d38938ac5a8b0eb5f5a87e2afdb61b9f:test-eu-west-1\\\\\\"\\"
+        \\"cdk-assets --path \\\\\\"assembly-test-mijn-gegevens-api/testmijngegevensapipersoonsgegevensapi9BDC5B79.assets.json\\\\\\" --verbose publish \\\\\\"75697e476d9322e42d3ee0f803537f0ef8ab72554bfdbe2f9408d6a1d4b9cd2c:test-eu-west-1\\\\\\"\\"
       ]
     }
   }

--- a/test/__snapshots__/main.test.ts.snap
+++ b/test/__snapshots__/main.test.ts.snap
@@ -52,7 +52,7 @@ Object {
     },
     \\"build\\": {
       \\"commands\\": [
-        \\"cdk-assets --path \\\\\\"assembly-test-mijn-gegevens-api/testmijngegevensapipersoonsgegevensapi9BDC5B79.assets.json\\\\\\" --verbose publish \\\\\\"5f588a39415fa09207fee2583d11ff4f14a81544009edbe4eef4cf194b4c48a5:test-eu-west-1\\\\\\"\\"
+        \\"cdk-assets --path \\\\\\"assembly-test-mijn-gegevens-api/testmijngegevensapipersoonsgegevensapi9BDC5B79.assets.json\\\\\\" --verbose publish \\\\\\"b811446fe28000c22f920ceba9a6f8f5d38938ac5a8b0eb5f5a87e2afdb61b9f:test-eu-west-1\\\\\\"\\"
       ]
     }
   }


### PR DESCRIPTION
GET requests to this function would fail with http 500 if users were not
 yet logged in. The session cookie was required in the handler.

This fixes that issue: The cookie is no longer required, if users are not logged in they will be redirected to the login page instead.