### PR TITLE
feat: Use session username

### DIFF
--- a/src/app/persoonsgegevens/persoonsgegevensRequestHandler.js
+++ b/src/app/persoonsgegevens/persoonsgegevensRequestHandler.js
@@ -29,7 +29,7 @@ async function handleLoggedinRequest(session, apiClient) {
 
     const brpData = await brpApi.getBrpData(bsn);
     const data = brpData;
-    data.volledigenaam = brpData?.Persoon?.Persoonsgegevens?.Naam ? brpData.Persoon.Persoonsgegevens.Naam : 'Onbekende gebruiker';
+    data.volledigenaam = session.getValue('username');
 
     data.title = 'Persoonsgegevens';
     data.shownav = true;

--- a/test/__snapshots__/main.test.ts.snap
+++ b/test/__snapshots__/main.test.ts.snap
@@ -52,7 +52,7 @@ Object {
     },
     \\"build\\": {
       \\"commands\\": [
-        \\"cdk-assets --path \\\\\\"assembly-test-mijn-gegevens-api/testmijngegevensapipersoonsgegevensapi9BDC5B79.assets.json\\\\\\" --verbose publish \\\\\\"75697e476d9322e42d3ee0f803537f0ef8ab72554bfdbe2f9408d6a1d4b9cd2c:test-eu-west-1\\\\\\"\\"
+        \\"cdk-assets --path \\\\\\"assembly-test-mijn-gegevens-api/testmijngegevensapipersoonsgegevensapi9BDC5B79.assets.json\\\\\\" --verbose publish \\\\\\"8b5bf58feb2e0cc42020b834a06942eccb3ca0362d5af961efe68eccf765a7a8:test-eu-west-1\\\\\\"\\"
       ]
     }
   }


### PR DESCRIPTION
Use the username stored in the session instead of in BRP API. It doesn't directly affect this function (it calls the BRP anyway) but this change aligns this function with the other routes, making future changes more clear.
